### PR TITLE
Add context dir

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,6 +50,12 @@ func main() {
 			Usage:  "Will execute multiple builds in parallel as defined in the template",
 			EnvVar: "PLUGIN_TEMPLATE",
 		},
+		cli.StringFlag{
+			Name:   "context",
+			Usage:  "The context directory path to use for executing `packer` command, defaults to root of the git repo",
+			Value:  ".",
+			EnvVar: "PLUGIN_CONTEXT",
+		},
 		cli.BoolFlag{
 			Name:   "syntax_only",
 			Usage:  "Only check syntax. Do not verify config of the template",
@@ -114,6 +120,7 @@ func run(c *cli.Context) error {
 			Actions:    c.StringSlice("actions"),
 			Vars:       vars,
 			Template:   c.String("template"),
+			Context:    c.String("context"),
 			VarFiles:   c.StringSlice("var_files"),
 			Except:     c.StringSlice("except"),
 			Only:       c.StringSlice("only"),

--- a/plugin.go
+++ b/plugin.go
@@ -14,6 +14,7 @@ type (
 		Actions    []string
 		Vars       map[string]string
 		Template   string
+		Context    string
 		VarFiles   []string
 		SyntaxOnly bool
 		Except     []string
@@ -57,10 +58,15 @@ func pkValidate(config Config) *exec.Cmd {
 	}
 
 	args = append(args, config.Template)
-	return exec.Command(
+
+	cmd := exec.Command(
 		"packer",
 		args...,
 	)
+
+	cmd.Dir = config.Context
+
+	return cmd
 }
 
 func pkBuild(config Config) *exec.Cmd {
@@ -105,10 +111,15 @@ func pkBuild(config Config) *exec.Cmd {
 	}
 
 	args = append(args, config.Template)
-	return exec.Command(
+
+	cmd := exec.Command(
 		"packer",
 		args...,
 	)
+
+	cmd.Dir = config.Context
+
+	return cmd
 }
 
 // Exec executes the plugin.


### PR DESCRIPTION
* Add `context` as parameter to use when the packer files are all
located in a relative path and not root itself

Fixes #3
