### PR TITLE
feat: add pkInit function for packer initialization

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,6 +86,11 @@ func main() {
 			Usage:  "Force a build to continue if artifacts exist, deletes existing artifacts",
 			EnvVar: "PLUGIN_FORCE",
 		},
+		cli.BoolFlag{
+			Name:   "upgrade",
+			Usage:  "On top of installing missing plugins, update installed plugins to the latest available version",
+			EnvVar: "PLUGIN_UPGRADE",
+		},
 	}
 
 	app.Version = Version
@@ -130,6 +135,7 @@ func run(c *cli.Context) error {
 			Parallel:   c.Bool("parallel"),
 			Readable:   c.Bool("readable"),
 			Force:      c.Bool("force"),
+			IsUpgrade:  c.Bool("upgrade"),
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -24,6 +24,7 @@ type (
 		Parallel   bool
 		Readable   bool
 		Force      bool
+		IsUpgrade  bool
 	}
 
 	// Plugin values
@@ -55,6 +56,27 @@ func pkValidate(config Config) *exec.Cmd {
 
 	if config.SyntaxOnly {
 		args = append(args, "-syntax-only")
+	}
+
+	args = append(args, config.Template)
+
+	cmd := exec.Command(
+		"packer",
+		args...,
+	)
+
+	cmd.Dir = config.Context
+
+	return cmd
+}
+
+func pkInit(config Config) *exec.Cmd {
+	args := []string{
+		"init",
+	}
+
+	if config.IsUpgrade {
+		args = append(args, "-upgrade")
 	}
 
 	args = append(args, config.Template)
@@ -138,6 +160,8 @@ func (p *Plugin) Exec() error {
 	// Add commands listed from Actions
 	for _, action := range p.Config.Actions {
 		switch action {
+		case "init":
+			commands = append(commands, pkInit(p.Config))
 		case "validate":
 			commands = append(commands, pkValidate(p.Config))
 		case "build":

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -129,3 +129,41 @@ func Test_pkBuild(t *testing.T) {
 		})
 	}
 }
+
+func Test_pkInit(t *testing.T) {
+	type args struct {
+		config Config
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "default command",
+			args: args{
+				config: Config{
+					Template: "aws-ubuntu.pkr.hcl",
+				},
+			},
+			want: "packer init aws-ubuntu.pkr.hcl",
+		},
+		{
+			name: "upgrade command",
+			args: args{
+				config: Config{
+					Template:  "aws-ubuntu.pkr.hcl",
+					IsUpgrade: true,
+				},
+			},
+			want: "packer init -upgrade aws-ubuntu.pkr.hcl",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pkInit(tt.args.config); got.String() != tt.want {
+				t.Errorf("pkInit() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/aws-ubuntu.pkr.hcl
+++ b/tests/aws-ubuntu.pkr.hcl
@@ -1,0 +1,8 @@
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 0.0.2"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}


### PR DESCRIPTION

- Add a new flag `upgrade` to `cli` with the description &#34;On top of installing missing plugins, update installed plugins to the latest available version&#34;
- Add a new function `pkInit` to `plugin.go` to execute `packer init` command with an optional `-upgrade` flag
- Add a new test for `pkInit` function in `plugin_test.go`
- Create a new file `tests/aws-ubuntu.pkr.hcl` with required plugins for packer

fix #24 
fix https://github.com/appleboy/drone-packer/issues/18